### PR TITLE
Expose IdToken and AccessToken instead of ActiveToken

### DIFF
--- a/src/Plugin.GoogleClient/GoogleClientManager.android.cs
+++ b/src/Plugin.GoogleClient/GoogleClientManager.android.cs
@@ -173,7 +173,8 @@ namespace Plugin.GoogleClient
             if (GoogleSignIn.GetLastSignedInAccount(CurrentActivity)!=null)
             {
                 //Auth.GoogleSignInApi.SignOut(GoogleApiClient);
-                _activeToken = null;
+                _idToken = null;
+                _accessToken = null;
                 mGoogleSignInClient.SignOut();
                 //GoogleApiClient.Disconnect();
 
@@ -197,8 +198,10 @@ namespace Plugin.GoogleClient
             }
         }
 
-        public string ActiveToken { get { return _activeToken; } }
-        static string _activeToken { get; set; }
+        public string IdToken { get { return _idToken; } }
+        public string AccessToken { get { return _accessToken; } }
+        static string _idToken { get; set; }
+        static string _accessToken { get; set; }
 
         static EventHandler<GoogleClientErrorEventArgs> _onError;
         public event EventHandler<GoogleClientErrorEventArgs> OnError
@@ -231,8 +234,8 @@ namespace Plugin.GoogleClient
                 Picture = new Uri((userAccount.PhotoUrl != null ? $"{userAccount.PhotoUrl}" : $"https://autisticdating.net/imgs/profile-placeholder.jpg"))
             };
 
-            _activeToken = userAccount.IdToken;
-            System.Console.WriteLine($"Active Token: {_activeToken}");
+            _idToken = userAccount.IdToken;
+            System.Console.WriteLine($"Id Token: {_idToken}");
 
 
             if (userAccount.GrantedScopes != null &&  userAccount.GrantedScopes.Count>0)
@@ -246,9 +249,9 @@ namespace Plugin.GoogleClient
 
                             System.Console.WriteLine($"Scopes: {scopes}");
 
-                            var accessToken = GoogleAuthUtil.GetToken(Application.Context, userAccount.Account, scopes);
+                            _accessToken = GoogleAuthUtil.GetToken(Application.Context, userAccount.Account, scopes);
 
-                            System.Console.WriteLine($"Access Token: {accessToken}");
+                            System.Console.WriteLine($"Access Token: {_accessToken}");
                          }
                         catch (Exception ex)
                         {

--- a/src/Plugin.GoogleClient/GoogleClientManager.apple.cs
+++ b/src/Plugin.GoogleClient/GoogleClientManager.apple.cs
@@ -19,8 +19,10 @@ namespace Plugin.GoogleClient
         // Class Debug Tag
         private String Tag = typeof(GoogleClientManager).FullName;
 
-        public string ActiveToken { get { return _activeToken; } }
-        string _activeToken { get; set; }
+        public string IdToken { get { return _idToken; } }
+        public string AccessToken { get { return _accessToken; } }
+        static string _idToken { get; set; }
+        static string _accessToken { get; set; }
         static string _clientId { get; set; }
 
         public GoogleUser CurrentUser
@@ -134,8 +136,10 @@ namespace Plugin.GoogleClient
                 {
                     if (error == null)
                     {
-                        _activeToken = authentication.AccessToken;
-                        System.Console.WriteLine($"Active Token: {_activeToken}");
+                        _accessToken = authentication.AccessToken;
+                        _idToken = authentication.IdToken;
+                        System.Console.WriteLine($"Id Token: {_idToken}");
+                        System.Console.WriteLine($"Access Token: {_accessToken}");
                     }
 
                 });
@@ -214,7 +218,8 @@ namespace Plugin.GoogleClient
 
             if (IsLoggedIn)
             {
-                _activeToken = null;
+                _idToken = null;
+                _accessToken = null;
                 SignIn.SharedInstance.SignOutUser();
                 // Send the logout result to the receivers
                 OnLogoutCompleted(EventArgs.Empty);
@@ -323,8 +328,10 @@ namespace Plugin.GoogleClient
                 {
                     if(error ==null)
                     {
-                        _activeToken = authentication.AccessToken;
-                        System.Console.WriteLine($"Active Token: {_activeToken}");
+                        _accessToken = authentication.AccessToken;
+                        _idToken = authentication.IdToken;
+                        System.Console.WriteLine($"Id Token: {_idToken}");
+                        System.Console.WriteLine($"Access Token: {_accessToken}");
                     }
              
                 });

--- a/src/Plugin.GoogleClient/IGoogleClientManager.shared.cs
+++ b/src/Plugin.GoogleClient/IGoogleClientManager.shared.cs
@@ -80,7 +80,8 @@ namespace Plugin.GoogleClient
         Task<GoogleResponse<GoogleUser>> LoginAsync();
         Task<GoogleResponse<GoogleUser>> SilentLoginAsync();
         void Logout();
-        string ActiveToken { get; }
+        string IdToken { get; }
+        string AccessToken { get; }
         GoogleUser CurrentUser { get; }
         bool IsLoggedIn { get; }
         //DateTime TokenExpirationDate { get; }


### PR DESCRIPTION
Exposes IdToken and AccessToken so that we can have the same behavior on iOS and Android.

Fixes #41 

Breaking change, removed ActiveToken so that they can decide if they need the Id or the Access token