### PR TITLE
[Docs] Android Build Action For VSMac

### DIFF
--- a/docs/GoogleFirebaseConsoleSetup.md
+++ b/docs/GoogleFirebaseConsoleSetup.md
@@ -63,7 +63,14 @@ Other alternative is to adding this method and calling it on the MainActivity On
    }
 ```
 
-**4.** Finally, you will be able to download the **google-services.json** file and add it to your **Xamarin.Android** project. Make sure build action is GoogleServicesJson
+**4.** Finally, you will be able to download the **google-services.json** file and add it to your **Xamarin.Android** project. Make sure build action is **GoogleServicesJson**
+
+> The **GoogleServicesJson** build action may be unavailable in visual studio for mac, manually add the following to YourProject.Android.csproj
+```xml
+<ItemGroup>
+  <GoogleServicesJson Include="google-services.json" />
+</ItemGroup>
+```
 
 ![Creating Application 4](https://github.com/CrossGeeks/GoogleClientPlugin/blob/master/images/ConfigurationFileAndroid.PNG?raw=true)
 


### PR DESCRIPTION
I was following this (superb btw) guide to implement google login in my forms app. I'm developing from Visual Studio For Mac 2019 and had to manually edit the csproj for the android project in order to set the correct build action.

In a forms project without the **GoogleServicesJson** build action present in the csproj, the option is not presented to the user through the visual studio gui:
![Project Without The Build Action](https://user-images.githubusercontent.com/33064621/93341396-f8362d80-f825-11ea-938e-bf38c91e368f.png)

Once the action has been added to the project, it is available as a build action.
![Project With The Build Action](https://user-images.githubusercontent.com/33064621/93341434-04ba8600-f826-11ea-9168-c1de70432756.png)

I've added a little clarification in step 4 to make the process clearer for vc mac users 😁